### PR TITLE
Update config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,3 +7,6 @@ theme = "reveal-hugo"
 baseName = "index"
 mediaType = "text/html"
 isHTML = true
+
+[markup]
+defaultMarkdownHandler = "blackfriday"


### PR DESCRIPTION
Added compatibility for Hugo > 0.60 since the new markup-engine Goldmark is not (yet) supported/fallback to Blackfriday.